### PR TITLE
fix: mise a jour selecteur CSS pour form (⏳ Attente formulaire éternel)

### DIFF
--- a/downloader.js
+++ b/downloader.js
@@ -16,7 +16,7 @@
       return;
     }
 
-    const form = document.querySelector('app-filtres form');
+    const form = document.querySelector('filtres form');
     if (!form) {
       console.log('⏳ Attente formulaire...');
       setTimeout(createDownloadButton, 2000);


### PR DESCRIPTION
Site ENEDIS a changé

```
<filtres ..>
  <form ...>
```

au lieu de 

```
<app-filtres ..>
  <form ..>
```

.. cela cause conso-downloader a ne plus trouver l'élement pour attacher son bouton et de continuer a chercher

`const form = document.querySelector('app-filtres form');`

```
⏳ Attente formulaire...
⏳ Attente formulaire...
⏳ Attente formulaire...
```
...

J'ai  n'ai testé mon fix que sur Firefox! car je n'ai pas l'habitude des outils Chrom(e/ium).

J'ai pu télécharger mon historique (dans Firefox) ou avant je ne voyais même jamais le bouton 'Télécharger toute mon histoire' (dans Chromium ou Firefox).

Comme le code devrait être compatible (l'extension fonctionnait parfaitement dans Firefox, avec juste le changement de sélecteur) je présume que cela devrait fonctionner en Chrom(e/ium), sans rien de plus.